### PR TITLE
link from citation to caption for HTML/PDF, custom PDF caption

### DIFF
--- a/R/captioner.R
+++ b/R/captioner.R
@@ -65,7 +65,7 @@
 
 captioner <- function(prefix = "Figure", auto_space = TRUE, levels = 1,
                       type = NULL, infix = ".", 
-                      link = FALSE, fmt = as.character(knitr::opts_knit$get()[['rmarkdown.pandoc.to']]))
+                      link = FALSE, fmt = knitr::opts_knit$get()[['rmarkdown.pandoc.to']])
 {
   ## Make sure all of the parameters are setup correctly ---
   

--- a/R/captioner.R
+++ b/R/captioner.R
@@ -188,7 +188,7 @@ captioner <- function(prefix = "Figure", auto_space = TRUE, levels = 1,
       s_cite    = sprintf('[%s%s](#%s)', prefix, obj_num, ref)
       s_num     = sprintf('[%s](#%s)', obj_num, ref)
     } else {
-      s_display = paste0(prefix, obj_num, ": ", caption, ' OTHER FORMAT: ', fmt)
+      s_display = paste0(prefix, obj_num, ": ", caption)
       s_cite    = paste0(prefix, obj_num)
       s_num     = obj_num
     }

--- a/R/captioner.R
+++ b/R/captioner.R
@@ -7,6 +7,7 @@
 #' @param levels Logical or number indicating whether or not you want hierarchical numbering, and if so, how many levels.  Hierarchical numbering is turned off by default.
 #' @param type Vector with same length as `levels` indicating whether figure numbering should be numeric ("n"), lowercase character ("c"), or uppercase character ("C").  If unspecified, `captioner` will revert to all numeric values.
 #' @param infix Character string containing text to go between figure numbers if hierarchical numbering is on.  Default is "."
+#' @param link Logical indicating whether you want citations linked to figures for HTML or PDF output. Default is FALSE.
 #' 
 #' @return A captioner function.
 #' 
@@ -29,6 +30,14 @@
 #' is modified based on the citations you use.  The first figure to be cited will be moved to the
 #' beginning of the list, becoming "Figure 1".
 #' 
+#' If \code{link = TRUE}, then citations are hyperlinked to the referenced
+#' caption. This only applies when rendering an Rmarkdown document to HTML or
+#' PDF (see \url{http://rmarkdown.rstudio.com}). For the link to work, the
+#' caption needs to be output using the option \code{fig_caption: yes} in the
+#' front matter of the Rmarkdown document. Since for PDF output, figure
+#' numbering is internally handled, this number gets used over the captioner
+#' generated number so special use of \code{level} does not get applied.
+#' 
 #' @examples
 #' \donttest{
 #' # Create a new captioner object:
@@ -48,11 +57,15 @@
 #' tables <- captioner(prefix = "Table", levels = 2)
 #' tables("a", "Table of world populations sorted from greatest to least.")
 #' }
+#' 
+#' # Create a captioner object with links (for HTML or PDF output):
+#' fig_nums <- captioner(link = TRUE)
 #'   
 #' @export
 
 captioner <- function(prefix = "Figure", auto_space = TRUE, levels = 1,
-                      type = NULL, infix = ".")
+                      type = NULL, infix = ".", 
+                      link = FALSE, fmt = as.character(knitr::opts_knit$get()[['rmarkdown.pandoc.to']]))
 {
   ## Make sure all of the parameters are setup correctly ---
   
@@ -163,17 +176,34 @@ captioner <- function(prefix = "Figure", auto_space = TRUE, levels = 1,
     # create display version of object number
     obj_num <- paste(objects$number[[obj_ind]], collapse = infix)
     
+    # get display output format from running rmarkdown::render()
+    ref = stringr::str_replace_all(sprintf('%s_%s', prefix, obj_num), ' ', '')
+    if (link & fmt == 'latex'){
+      # note that prefix is dropped for PDF output since automatically handles this
+      s_display = sprintf('%s\\label{%s}', caption, ref)
+      s_cite    = sprintf('%s\\ref{%s}', prefix, ref)
+      s_num     = sprintf('\\ref{%s}', ref)
+    } else if (link & fmt == 'html'){
+      s_display = sprintf('<a name="%s"}></a>%s%s: %s', ref, prefix, obj_num, caption)
+      s_cite    = sprintf('[%s%s](#%s)', prefix, obj_num, ref)
+      s_num     = sprintf('[%s](#%s)', obj_num, ref)
+    } else {
+      s_display = paste0(prefix, obj_num, ": ", caption, ' OTHER FORMAT: ', fmt)
+      s_cite    = paste0(prefix, obj_num)
+      s_num     = obj_num
+    }
+    
     # choose display format and return
     
     # for backwards compatibility, use the cite and num options first
     if(cite){
       .Deprecated(new = "display", old = "cite")
-      return(paste0(prefix, obj_num))
-    }
+      return(s_cite)
+     }
     
     if(num){
       .Deprecated(new = "display", old = "num")
-      return(obj_num)
+      return(s_num)
     }
     
     if(display == FALSE)
@@ -182,15 +212,15 @@ captioner <- function(prefix = "Figure", auto_space = TRUE, levels = 1,
     }
     else if(display == "full" || display == "f")
     {
-      return(paste0(prefix, obj_num, ": ", caption))
+      return(s_display)
     }
     else if(display == "cite" || display == "c")
     {
-      return(paste0(prefix, obj_num))
+      return(s_cite)
     }
     else if(display == "num"  || display == "n")
     {
-      return(obj_num)
+      return(s_num)
     }
     else
     {

--- a/man/captioner.Rd
+++ b/man/captioner.Rd
@@ -5,7 +5,8 @@
 \title{Captioner function}
 \usage{
 captioner(prefix = "Figure", auto_space = TRUE, levels = 1, type = NULL,
-  infix = ".")
+  infix = ".", link = FALSE,
+  fmt = as.character(knitr::opts_knit$get()[["rmarkdown.pandoc.to"]]))
 }
 \arguments{
 \item{prefix}{Character string containing text to go before object number. The default is "Figure".}
@@ -17,6 +18,8 @@ captioner(prefix = "Figure", auto_space = TRUE, levels = 1, type = NULL,
 \item{type}{Vector with same length as `levels` indicating whether figure numbering should be numeric ("n"), lowercase character ("c"), or uppercase character ("C").  If unspecified, `captioner` will revert to all numeric values.}
 
 \item{infix}{Character string containing text to go between figure numbers if hierarchical numbering is on.  Default is "."}
+
+\item{link}{Logical indicating whether you want citations linked to figures for HTML or PDF output. Default is FALSE.}
 }
 \value{
 A captioner function.
@@ -43,6 +46,14 @@ And returns a character string containing the prefix and object number with or w
 The initial numbering is determined based on the order of caption creation.  However, this order
 is modified based on the citations you use.  The first figure to be cited will be moved to the
 beginning of the list, becoming "Figure 1".
+
+If \code{link = TRUE}, then citations are hyperlinked to the referenced
+caption. This only applies when rendering an Rmarkdown document to HTML or
+PDF (see \url{http://rmarkdown.rstudio.com}). For the link to work, the
+caption needs to be output using the option \code{fig_caption: yes} in the
+front matter of the Rmarkdown document. Since for PDF output, figure
+numbering is internally handled, this number gets used over the captioner
+generated number so special use of \code{level} does not get applied.
 }
 \examples{
 \donttest{
@@ -63,5 +74,8 @@ fig_nums("flower_plot")
 tables <- captioner(prefix = "Table", levels = 2)
 tables("a", "Table of world populations sorted from greatest to least.")
 }
+
+# Create a captioner object with links (for HTML or PDF output):
+fig_nums <- captioner(link = TRUE)
 }
 

--- a/vignettes/using_captioner.Rmd
+++ b/vignettes/using_captioner.Rmd
@@ -179,7 +179,7 @@ figs_2("C", "The letter C shown in fixed-width fonts.")
 
 If you want figure numbers with more depth, say if you have a figure with subfigures, or have figure numbers attached to sections, you can implement hierarchical numbering.  This will give you, for example, something like "Figure 1.1.1".
 
-### Linking to Figures / Tables
+### Linking from Citation to Caption in HTML or PDF
 
 You may want to link from the citation to the caption for easy reference. For HTML, an HTML anchor `<a name="id"}></a>` is placed before the caption and markdown style internal link `[](#id)` used for the citation.
 
@@ -199,4 +199,4 @@ fig("sausage", display = "cite")
 
 Since for PDF output figure numbering is internally handled, display of special numbering otherwise defined in the `level` argument is ignored in the citation and caption output PDF. This further handles the duplication of caption labels, such as "Figure 1: Figure 1:" that you would otherwise see when not using the `link = TRUE` option and pdf output.
 
-The output type will be detected from using `rmarkdown::render()`, whether by command or using the Knit dropdown menu when editing an Rmarkdown document in the RStudio IDE (see [rmarkdown.rstudio.com](http://rmarkdown.rstudio.com/). The argument  `fmt` used above is not documented in the captioner function, but used here in the vignette simply to show the different renderings of the intermediary markdown document before being passed along to [pandoc](http://pandoc.org).
+The output type will be detected from using `rmarkdown::render()`, whether by command or using the Knit dropdown menu when editing an Rmarkdown document in the RStudio IDE (see [rmarkdown.rstudio.com](http://rmarkdown.rstudio.com/)). The argument  `fmt` used above is not documented in the captioner function, but used here in the vignette simply to show the different renderings of the intermediary markdown document before being passed along to [pandoc](http://pandoc.org).

--- a/vignettes/using_captioner.Rmd
+++ b/vignettes/using_captioner.Rmd
@@ -177,3 +177,26 @@ bump(figs_2, level = 1)
 figs_2("C", "The letter C shown in fixed-width fonts.")
 ```
 
+If you want figure numbers with more depth, say if you have a figure with subfigures, or have figure numbers attached to sections, you can implement hierarchical numbering.  This will give you, for example, something like "Figure 1.1.1".
+
+### Linking to Figures / Tables
+
+You may want to link from the citation to the caption for easy reference. For HTML, an HTML anchor `<a name="id"}></a>` is placed before the caption and markdown style internal link `[](#id)` used for the citation.
+
+```{r link_html}
+fig <- captioner(link = TRUE)
+fig("sausage", "Never saw such links!")
+fig("sausage", display = "cite")
+```
+
+For PDF, a [Latex cross-referencing](https://en.wikibooks.org/wiki/LaTeX/Labels_and_Cross-referencing#Introduction) technique of `\label{id}` and `\ref{id}` are used. 
+
+```{r link_pdf}
+fig <- captioner(link = TRUE, fmt = 'latex')
+fig("sausage", "Never saw such links!")
+fig("sausage", display = "cite")
+```
+
+Since for PDF output figure numbering is internally handled, display of special numbering otherwise defined in the `level` argument is ignored in the citation and caption output PDF. This further handles the duplication of caption labels, such as "Figure 1: Figure 1:" that you would otherwise see when not using the `link = TRUE` option and pdf output.
+
+The output type will be detected from using `rmarkdown::render()`, whether by command or using the Knit dropdown menu when editing an Rmarkdown document in the RStudio IDE (see [rmarkdown.rstudio.com](http://rmarkdown.rstudio.com/). The argument  `fmt` used above is not documented in the captioner function, but used here in the vignette simply to show the different renderings of the intermediary markdown document before being passed along to [pandoc](http://pandoc.org).


### PR DESCRIPTION
Hi @adletaw,

Thanks so much for this great package! I've added a little `link` argument to the captioner function to customize HTML and PDF outputs for linking from citation to caption. The intended output type is determined with `fmt = knitr::opts_knit$get()[['rmarkdown.pandoc.to']]`.

I was originally motivated to write this because of wanting a single manuscript to output as HTML (for web), PDF (for final) and DOC (for track changes with coauthors). But outputting to PDF generates "Figure 1: Figure 1-1" or similar since labeling gets handled internally. So now the prefix and number get stripped in the caption for PDF, ie deferring to internal LaTex handling.

This might also help with #13, #6.

From the vignette addendum...

### Linking to Figures / Tables

You may want to link from the citation to the caption for easy reference. For HTML, an HTML anchor `<a name="id"}></a>` is placed before the caption and markdown style internal link `[](#id)` used for the citation.

```{r link_html}
fig <- captioner(link = TRUE)
fig("sausage", "Never saw such links!")
fig("sausage", display = "cite")
```
```
## [1] "<a name=\"Figure_1\"}></a>Figure  1: Never saw such links!"
## [1] "[Figure  1](#Figure_1)"
```

For PDF, a [Latex cross-referencing](https://en.wikibooks.org/wiki/LaTeX/Labels_and_Cross-referencing#Introduction) technique of `\label{id}` and `\ref{id}` are used. 

```{r link_pdf}
fig <- captioner(link = TRUE, fmt = 'latex')
fig("sausage", "Never saw such links!")
fig("sausage", display = "cite")
```
```
## [1] "Never saw such links!\\label{Figure_1}"
## [1] "Figure  \\ref{Figure_1}" 
```

Since for PDF output figure numbering is internally handled, display of special numbering otherwise defined in the `level` argument is ignored in the citation and caption output PDF. This further handles the duplication of caption labels, such as "Figure 1: Figure 1:" that you would otherwise see when not using the `link = TRUE` option and pdf output.

The output type will be detected from using `rmarkdown::render()`, whether by command or using the Knit dropdown menu when editing an Rmarkdown document in the RStudio IDE (see [rmarkdown.rstudio.com](http://rmarkdown.rstudio.com/). The argument  `fmt` used above is not documented in the captioner function, but used here in the vignette simply to show the different renderings of the intermediary markdown document before being passed along to [pandoc](http://pandoc.org).