### PR TITLE
Adding Css Class Parameter

### DIFF
--- a/R/captioner.R
+++ b/R/captioner.R
@@ -13,6 +13,8 @@
 #' If unspecified, \code{captioner} will revert to all numeric values.
 #' @param infix Character string containing text to go between figure numbers if hierarchical
 #' numbering is on.  Default is \emph{.}
+#' @param css_class Assign a css class to the caption. Places the caption into 
+#' a span html element with a class.
 #' 
 #' @return A captioner function.
 #' 
@@ -52,7 +54,7 @@
 #' @export
 
 captioner <- function(prefix = "Figure", auto_space = TRUE, levels = 1,
-                      type = NULL, infix = ".")
+                      type = NULL, infix = ".", css_class = NULL)
 {
   ## Make sure all of the parameters are setup correctly ---
   
@@ -182,7 +184,14 @@ captioner <- function(prefix = "Figure", auto_space = TRUE, levels = 1,
     }
     else if(display == "full" || display == "f")
     {
-      return(paste0(prefix, obj_num, ": ", caption))
+      cap.text <- paste0(prefix, obj_num, ": ", caption)
+      if (!is.null(css_class))
+      {
+        cap.text <- paste0("<span class=\"", 
+                           css_class, "\">", cap.text, 
+                           "</span>")
+      }
+      return(cap.text)
     }
     else if(display == "cite" || display == "c")
     {

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
 
 *captioner* is now available on CRAN. If you would like to install the current development version:
 
--   `install.packages("devtools")`
--   `devtools::install_github("adletaw/captioner")`
+-   `r install.packages("devtools")`
+-   `r devtools::install_github("tinyheero/captioner")`
 
 or if you want the vignette:
 

--- a/README.md
+++ b/README.md
@@ -7,8 +7,10 @@
 
 *captioner* is now available on CRAN. If you would like to install the current development version:
 
--   `r install.packages("devtools")`
--   `r devtools::install_github("tinyheero/captioner")`
+```{r}
+install.packages("devtools")
+devtools::install_github("tinyheero/captioner")
+```
 
 or if you want the vignette:
 

--- a/man/captioner.Rd
+++ b/man/captioner.Rd
@@ -5,7 +5,7 @@
 \title{Captioner function}
 \usage{
 captioner(prefix = "Figure", auto_space = TRUE, levels = 1, type = NULL,
-  infix = ".")
+  infix = ".", css_class = NULL)
 }
 \arguments{
 \item{prefix}{Character string containing text to go before object number.
@@ -23,6 +23,9 @@ If unspecified, \code{captioner} will revert to all numeric values.}
 
 \item{infix}{Character string containing text to go between figure numbers if hierarchical
 numbering is on.  Default is \emph{.}}
+
+\item{css_class}{Assign a css class to the caption. Places the caption into
+a span html element with a class.}
 }
 \value{
 A captioner function.


### PR DESCRIPTION
Implements the suggestion https://github.com/adletaw/captioner/issues/23

Places the caption text into a span element with a css class.